### PR TITLE
Multiple query genes support for SHOOT (with EPA)

### DIFF
--- a/shoot/__main__.py
+++ b/shoot/__main__.py
@@ -65,34 +65,63 @@ def main(d_db, infn, opts):
     # Fix up accession if required
     fn_for_use, _ = clean_fasta(infn)
 
+    # Get genes.
+    infile = open(fn_for_use, 'r')
+    fasta_data = infile.read()
+    genes = dict(re.findall(r"^>([^\n]+)\n([^>]+)", fasta_data, re.MULTILINE))
+    infile.close()
+
     # Assign to tree 
     og_assign = og_assigner.OGAssignDIAMOND(d_db, 
                                             opts.nthreads, 
                                             opts.q_profiles_all)
-    ogs, scores = og_assign.assign(fn_for_use, q_ultra_sens=opts.search_high_sens)
-    if len(ogs) == 0:
-        print("No homologs found for sequence in this database")
-        return 
-    if opts.q_full_tree:
-        ogs, scores = utils.og_parts_to_ogs(ogs, scores)
-    if len(ogs) > 1:
-        print("Assignment to homolog group is ambiguous, %d possibilities:" % len(ogs))
-        print("Group       E-value")
-        for og, score in zip(ogs, scores):
-            print("%-11s %g" % (og, score))
-        if opts.q_ambiguous:
-            print("\nWill attempt placement in each of these trees.")
+    # assignations is a dict which keys are gene names and values are dicts
+    # with 2 keys:
+    #   'ogs': stores the ordered list of assigned OGs
+    #   'scores': stores the ordered list of the corresponding e-values
+    assignations = og_assign.assign(fn_for_use, q_ultra_sens=opts.search_high_sens)
+    
+    # orphans is a list of orphan gene names.
+    orphans = []
+    # aogs are lists of gene names (as values) assigned to OGs identifiers (as keys).
+    aogs = {}
+    for gene, ga in assignations.items():
+        ogs = ga['ogs']
+        scores = ga['scores']
+        if len(ogs) == 0:
+            print("No homologs found for sequence %s in this database" % gene)
+            orphans.append(gene)
+            continue
+        if opts.q_full_tree:
+            ogs, scores = utils.og_parts_to_ogs(ogs, scores)
+        if len(ogs) > 1:
+            print("Assignment of %s to homolog group is ambiguous, %d possibilities:" % (gene, len(ogs)))
+            print("Group       E-value")
+            for og, score in zip(ogs, scores):
+                print("%-11s %g" % (og, score))
+            if opts.q_ambiguous:
+                print("\nWill attempt placement in each of these trees.")
+            else:
+                ogs = ogs[:1]
+                print("\nWill attempt placement n best hit tree: %s" % ogs[0])
         else:
-            ogs = ogs[:1]
-            print("\nWill attempt placement n best hit tree: %s" % ogs[0])
-    else:
-        # Unambiguous placement
-        print("Sequence assigned to homolog group %s with e-value %g" % (ogs[0], scores[0])) 
-        
+            # Unambiguous placement
+            print("Sequence %s assigned to homolog group OG%s with e-value %g" % (gene, ogs[0], scores[0])) 
+        assignations[gene]['ogs'] = ogs
+        assignations[gene]['scores'] = scores
+        for og in ogs:
+            if og not in aogs:
+                aogs[og] = []
+            aogs[og].append(gene)
+
+
     db_name = os.path.basename(d_db[:-1]) 
     with open(infn + ".assign.txt", 'w') as outfile:
         outfile.write("%s\n" % (db_name))
-    for i_tree, (og_part, score) in enumerate(zip(ogs, scores)):
+
+    #for i_tree, (og_part, score) in enumerate(zip(ogs, scores)):
+    for i_tree, (og_part, og_genes) in enumerate(aogs.items()):
+        og_infn = infn + '.OG' + og_part + '.fa'
         # Place in tree
         warn_str = ""
         if "iqtree" == opts.tree_method:
@@ -102,16 +131,29 @@ def main(d_db, infn, opts):
         else:
             print("ERROR: %s method has not been implemented" % opts.tree_method)
             return
-        fn_tree, query_gene_name_final, warn_str = graft.add_gene(
+        # Prepare OG fasta.
+        og_fasta = ''
+        for og_gene in og_genes:
+            og_fasta = og_fasta + '>' + og_gene + '\n' + genes[og_gene] + '\n'
+        with open(og_infn, 'w') as outfile:
+            outfile.write(og_fasta)
+        fn_tree, query_gene_names_final, warn_str = graft.add_gene(
                                         og_part, 
-                                        fn_for_use, 
-                                        infn, 
+                                        og_infn,
+                                        og_infn,
                                         q_mafft_acc=opts.q_mafft_accelerated,
                                         tree_method=opts.tree_method,
                                         )
-        db_name = os.path.basename(d_db[:-1])
+        scores = []
+        for qgene in query_gene_names_final:
+            # get the gene score for the selected OG (og_part).
+            qogs = assignations[qgene]['ogs']
+            qscores = assignations[qgene]['scores']
+            qscores = dict(zip(qogs, qscores))
+            scores.append(qscores[og_part])
+
         with open(infn + ".assign.txt", 'a') as outfile:
-            outfile.write("%d\t%s\t%g\t%s\n" % (i_tree, og_part, score, query_gene_name_final))
+            outfile.write("%d\t%s\t%s\t%s\n" % (i_tree, og_part, ','.join(map("{:g}".format, scores)), ','.join(query_gene_names_final)))
         if len(ogs) > 1:
             fn_old = fn_tree
             fn_tree = os.path.splitext(fn_tree)[0] + ".%d.tre" % i_tree
@@ -120,34 +162,35 @@ def main(d_db, infn, opts):
         print("Tree: %s" % fn_tree)  
         if warn_str != "":
             print("WARNING: " + warn_str) 
-            
+
         q_need_to_print = opts.q_print
         if opts.nU is not None:
             # if only nL is specified alone that has no effect
-            t = ete3.Tree(fn_tree)
-            if len(t) > opts.nU:
-                node = t & query_gene
-                while len(node) < opts.nU:
-                    node_prev = node
-                    n_taxa_prev = len(node)
-                    node = node.up
-                # now there are more than nU genes in this tree, step down one
-                # unless it is fewer than nL
-                node = node_prev if (opts.nL is None or n_taxa_prev >= opts.nL) else node
-                nwk_str = node.write()
-                with open(fn_tree, 'w') as outfile:
-                    outfile.write(nwk_str)
-                if q_need_to_print:
-                    print(nwk_str)
-                    q_need_to_print = False
+            for og_gene in og_genes:
+                t = ete3.Tree(fn_tree)
+                if len(t) > opts.nU:
+                    node = t & og_gene
+                    while len(node) < opts.nU:
+                        node_prev = node
+                        n_taxa_prev = len(node)
+                        node = node.up
+                    # now there are more than nU genes in this tree, step down one
+                    # unless it is fewer than nL
+                    node = node_prev if (opts.nL is None or n_taxa_prev >= opts.nL) else node
+                    nwk_str = node.write()
+                    with open(fn_tree, 'w') as outfile:
+                        outfile.write(nwk_str)
+                    if q_need_to_print:
+                        print(nwk_str)
+                        q_need_to_print = False
 
         if q_need_to_print:
             with open(fn_tree, 'r') as infile:
                 print(next(infile).rstrip())   # remove any trailing newline characters
 
         if opts.q_orthologs:
-            fn_ologs = fn_for_use + ".sh.orthologs.tsv"
-            write_orthologs(fn_tree, fn_ologs, query_gene)
+            fn_ologs = fn_for_use + '.OG' + og_part + ".sh.orthologs.tsv"
+            write_orthologs(fn_tree, fn_ologs, og_genes)
  
 
 def is_fasta(infn):
@@ -166,7 +209,7 @@ def is_fasta(infn):
 
 def clean_fasta(infn):
     """
-    If the accession contains problematic characters write a new file and return
+    If accessions contain problematic characters, write a new file and return
     its filename, otherwise return the original filename
     Args:
         infn - User input filename
@@ -174,18 +217,28 @@ def clean_fasta(infn):
         fn_for_use - file to use going forward for SHOOT
     """
     with open(infn, 'r') as infile:
-        acc = next(infile)
-        name = acc.rstrip()[1:]
-        name_cleaned = re.sub(gene_name_disallowed_chars_re, '_', name)
-        if name == name_cleaned:
+        name_mapping = {}
+        fasta_data = infile.read()
+        gene_name_matches = re.findall(r"^>([^\n]+)", fasta_data, re.MULTILINE)
+        already_clean = True
+        for gene_name in gene_name_matches:
+            name_cleaned = re.sub(gene_name_disallowed_chars_re, '_', gene_name)
+            if gene_name != name_cleaned:
+                fasta_data = fasta_data.replace('>' + gene_name, '>' + name_cleaned)
+                already_clean = False
+            name_mapping[gene_name] = name_cleaned
+
+        if already_clean:
             fn_for_use = infn
         else:
             # otherwise, need to create a new file
             fn_for_use = infn + ".sh.cleaned"
             with open(fn_for_use, 'w') as outfile:
-                outfile.write(">%s\n" % name_cleaned)
-                for l in infile:
-                    outfile.write(l)
+                outfile.write(fasta_data)
+            map_file = infn + ".sh.map"
+            with open(map_file, 'w') as outfile:
+                for gene_name, name_cleaned in name_mapping.items():
+                    outfile.write(gene_name + '\t' + name_cleaned + '\n')
         return fn_for_use, name_cleaned
 
 
@@ -200,7 +253,7 @@ def gene_to_species(name):
     return "_".join(name.split("_")[:2])
 
 
-def write_orthologs(fn_tree, fn_ologs, gene_name):
+def write_orthologs(fn_tree, fn_ologs, gene_names):
     """
     Write the orthologs of the query gene to file
     Args:
@@ -211,25 +264,31 @@ def write_orthologs(fn_tree, fn_ologs, gene_name):
     t = ete3.Tree(fn_tree)
     with open(fn_ologs, 'wt') as outfile:
         writer = csv.writer(outfile, delimiter="\t")
-        writer.writerow(["Species", "Orthologs"])
-        n = t & gene_name
-        n_prev = n
-        species_query_branch = set()
-        while n.up is not None:
-            n = n.up
-            n_other = [node for node in n.children if node != n_prev]
-            genes_other = [gene for node in n_other for gene in node.get_leaf_names()]
-            species_other = set([gene_to_species(gene) for gene in genes_other])
-            overlap = species_query_branch.intersection(species_other)
-            o = len(overlap)
-            m = min(len(species_other), len(species_query_branch))
-            if o == 0 or (m >= 4 and o == 1) or (m >= 9 and o ==2):
-                add_orthologs_to_file(writer, genes_other, overlap)
+        writer.writerow(["Query", "Species", "Orthologs"])
+        for gene_name in gene_names:
+            try:
+                n = t & gene_name
+            except ete3.coretype.tree.TreeError as ex:
+                print('Gene %s not found in tree!' % gene_name)
+                print(t)
+                raise
             n_prev = n
-            species_query_branch.update(species_other)
+            species_query_branch = set()
+            while n.up is not None:
+                n = n.up
+                n_other = [node for node in n.children if node != n_prev]
+                genes_other = [gene for node in n_other for gene in node.get_leaf_names()]
+                species_other = set([gene_to_species(gene) for gene in genes_other])
+                overlap = species_query_branch.intersection(species_other)
+                o = len(overlap)
+                m = min(len(species_other), len(species_query_branch))
+                if o == 0 or (m >= 4 and o == 1) or (m >= 9 and o ==2):
+                    add_orthologs_to_file(writer, gene_name, genes_other, overlap)
+                n_prev = n
+                species_query_branch.update(species_other)
 
 
-def add_orthologs_to_file(writer, genes, overlap):
+def add_orthologs_to_file(writer, gene_name, genes, overlap):
     """
     Add the genes below the nodes in n_other to the the csv writer as orthologs
     Args:
@@ -243,7 +302,7 @@ def add_orthologs_to_file(writer, genes, overlap):
     for sp in sorted(species_to_genes.keys()):
         if sp in overlap:
             continue
-        writer.writerow([sp, ", ".join(species_to_genes[sp])])
+        writer.writerow([gene_name, sp, ", ".join(species_to_genes[sp])])
 
 
 def clean_dir_name(dname):

--- a/shoot/__main__.py
+++ b/shoot/__main__.py
@@ -189,7 +189,7 @@ def main(d_db, infn, opts):
                 print(next(infile).rstrip())   # remove any trailing newline characters
 
         if opts.q_orthologs:
-            fn_ologs = fn_for_use + '.OG' + og_part + ".sh.orthologs.tsv"
+            fn_ologs = og_infn + ".sh.orthologs.tsv"
             write_orthologs(fn_tree, fn_ologs, og_genes)
  
 

--- a/shoot/msa_grafter.py
+++ b/shoot/msa_grafter.py
@@ -44,7 +44,7 @@ class MSAGrafter(object):
             to name_orig in the final tree
         """
         q_subtree = "." in og_part
-        fn_final_tree = fn_out_base + '.OG' + og_part + ".shoot.tre"
+        fn_final_tree = fn_out_base + ".shoot.tre"
         warn_string = ""
         fn_msa_orig = self.db.fn_msa(og_part)
         if not os.path.exists(fn_msa_orig):

--- a/shoot/msa_grafter.py
+++ b/shoot/msa_grafter.py
@@ -31,7 +31,7 @@ class MSAGrafter(object):
         """
         Args:
             og_part - the OG or OG.PART to search in
-            infn - FASTA filename containing the gene sequence
+            infn - FASTA filename containing the gene sequences
             fn_out_base - filenname onto which to build output files 
             q_mafft_acc - use accelerated MAFFT options instead of default
             tree_method - {iqtree,epa}
@@ -44,7 +44,7 @@ class MSAGrafter(object):
             to name_orig in the final tree
         """
         q_subtree = "." in og_part
-        fn_final_tree = fn_out_base + ".shoot.tre"
+        fn_final_tree = fn_out_base + '.OG' + og_part + ".shoot.tre"
         warn_string = ""
         fn_msa_orig = self.db.fn_msa(og_part)
         if not os.path.exists(fn_msa_orig):
@@ -53,27 +53,35 @@ class MSAGrafter(object):
         n_seqs_orig_123many = self.n_seqs_1234(fn_msa_orig)
         genes = self.get_gene_names(fn_msa_orig)
         
-        query_name = self.iqtree_names_adjust(self.get_gene_names(infn))[0]
+        org_query_names = self.iqtree_names_adjust(self.get_gene_names(infn))
         genes_set = set(genes)
-        if query_name in genes_set:
-            while query_name in genes_set:
-                query_name = "SHOOT_" + query_name
-            fn_input_to_msa = self.rename_gene(infn, query_name)
+        query_renames = {}
+        query_names = []
+        for query_name in org_query_names:
+            new_query_name = query_name
+            if new_query_name in genes_set:
+                while new_query_name in genes_set:
+                    new_query_name = "SHOOT_" + new_query_name
+                query_renames[query_name] = new_query_name
+            query_names.append(new_query_name)
+        if query_renames:
+            fn_input_to_msa = self.rename_genes(infn, query_renames)
         else:
             fn_input_to_msa = infn
-        genes.append(query_name)
+        # query_names = list(query_renames)
+        genes = genes + query_names
         fn_msa_new = fn_out_base + ".sh.msa.fa"
         mafft_opts = "--retree 1 --maxiterate 0 --nofft" if q_mafft_acc else ""
         subprocess.call("mafft --anysymbol %s --thread %d --quiet --add %s %s > %s" % (
                 mafft_opts, self.nthreads, fn_input_to_msa, fn_msa_orig, fn_msa_new), 
                 shell=True)
         if n_seqs_orig_123many >= 3:
-            fn_tree_new = self.run_tree_inference(og_part, n_seqs_orig_123many, fn_msa_new, q_subtree)
+            fn_tree_new = self.run_tree_inference(og_part, n_seqs_orig_123many, fn_msa_new, q_subtree, query_names)
         else:
             if not q_subtree:
                 self.write_trivial_tree(genes, fn_final_tree)
                 # warn_string = "Tree could not be rooted"
-                return fn_final_tree, query_name, warn_string
+                return fn_final_tree, query_names, warn_string
 
         # Rooting
         if not q_subtree:
@@ -90,12 +98,12 @@ class MSAGrafter(object):
             nwk_str = self.reconstruct_super_tree(og_part, t_sup, nwk_sub)
         
         if tree_method == "iqtree":
-            query_name = self.iqtree_names_adjust([query_name, ])[0]
+            query_names = self.iqtree_names_adjust(query_names)
             # with EPA we get a correct support value
-            nwk_str = self.remove_support_for_gene_placement(nwk_str, query_name)
+            nwk_str = self.remove_support_for_gene_placement(nwk_str, query_names)
         with open(fn_final_tree, 'w') as outfile:
             outfile.write(nwk_str)
-        return fn_final_tree, query_name, warn_string
+        return fn_final_tree, query_names, warn_string
 
     def root_independent_tree(self, og_part, fn_tree_new, n_seqs_123many, iq_name_adjust):
         """
@@ -207,7 +215,7 @@ class MSAGrafter(object):
 
 
     @staticmethod
-    def remove_support_for_gene_placement(nwk_str, gene_name):
+    def remove_support_for_gene_placement(nwk_str, gene_names):
         """
         No bootstrap analysis has been done on placement of query gene so remove 
         the support value incorrectly written by ete3 for its placement
@@ -218,29 +226,31 @@ class MSAGrafter(object):
             Traverse from query gene until finding its closing bracket. If extra
             opening brackets are found during the traverse then theymust be closed first
         """
-        n = len(nwk_str)
-        i = nwk_str.find(gene_name)
-        if i == -1:
-            # Error, gene should be in tree
-            return nwk_str
-        i += len(gene_name)
-        if i>=n:
-            # Error, gene name should be followed by more of the newick string
-            return nwk_str
-        exp_braces = 1
-        while i<n:
-            if nwk_str[i] == ")":
-                exp_braces -= 1
-            elif nwk_str[i] == "(":
-                exp_braces += 1
-            i+=1
-            if exp_braces == 0:
-                # found the location of the support value
-                break
-        i_rm0 = i
-        while nwk_str[i].isdigit() or nwk_str[i] == ".":
-            i+=1
-        nwk_str = nwk_str[:i_rm0] + nwk_str[i:]
+        for gene_name in gene_names:
+            n = len(nwk_str)
+            i = nwk_str.find(gene_name)
+            if i == -1:
+                # Error, gene should be in tree
+                continue
+            i += len(gene_name)
+            if i>=n:
+                # Error, gene name should be followed by more of the newick string
+                continue
+            exp_braces = 1
+            while i<n:
+                if nwk_str[i] == ")":
+                    exp_braces -= 1
+                elif nwk_str[i] == "(":
+                    exp_braces += 1
+                i+=1
+                if exp_braces == 0:
+                    # found the location of the support value
+                    break
+            i_rm0 = i
+            while nwk_str[i].isdigit() or nwk_str[i] == ".":
+                i+=1
+            nwk_str = nwk_str[:i_rm0] + nwk_str[i:]
+
         return nwk_str
 
 
@@ -287,11 +297,11 @@ class MSAGrafter(object):
         return nwk
 
 
-    def run_tree_inference(self, og_part, n_seqs_123many, fn_msa, q_subtree):
-        return self.run_iqtree(og_part, n_seqs_123many, fn_msa, q_subtree)
+    def run_tree_inference(self, og_part, n_seqs_123many, fn_msa, q_subtree, query_names):
+        return self.run_iqtree(og_part, n_seqs_123many, fn_msa, q_subtree, query_names)
 
 
-    def run_iqtree(self, og_part, n_seqs_123many, fn_msa, q_subtree):
+    def run_iqtree(self, og_part, n_seqs_123many, fn_msa, q_subtree, query_names):
         """
         Run IQTREE
         Args:
@@ -299,6 +309,7 @@ class MSAGrafter(object):
             n_seqs_123many - Lower bound on number of seqs in original tree, one of {1,2,3,4}
             fn_msa - the MSA
             q_subtree - is the gene assigned to a subtree
+            query_names - list of query genes
         Implementation:
         - >=4 genes: unroot the starting tree & run iqtree
         - 3 genes: run iqtree from scratch
@@ -359,14 +370,16 @@ class MSAGrafter(object):
 
 
     @staticmethod
-    def rename_gene(infn, new_query_name):
+    def rename_genes(infn, new_query_names):
         fn_new = infn + ".rn.fa"
-        with open(infn, 'r') as infile, open(fn_new, 'w') as outfile:
-            for l in infile:
-                if l.startswith(">"):
-                    outfile.write(">%s\n" % new_query_name)
-                else:
-                    outfile.write(l)
+        infile = open(infn, 'r')
+        fasta = infile.read()
+        infile.close()
+        outfile = open(fn_new, 'w')
+        for query_name, new_query_name in new_query_names:
+            fasta = re.sub('>' + re.escape(query_name) + '(?=\s)', '>' + new_query_name, fasta)
+        outfile.write(fasta)
+        outfile.close()
         return fn_new
 
 

--- a/shoot/og_assigner.py
+++ b/shoot/og_assigner.py
@@ -1,5 +1,6 @@
-import os 
+import os
 import sys
+import re
 import gzip
 import csv
 import argparse
@@ -40,9 +41,10 @@ class OGAssignDIAMOND(OGAssigner):
         Assign a sequence to an orthogroup
         Args:
             infn - Input FASTA filename
-        Returns
-            iogs - List[index of OG]
-            scores - List[e-values]
+        Returns:
+            assignations: a dictionay of gene name with their:
+                iogs - List[index of OG]
+                scores - List[e-values]
         """
         ext_cleaned = ".sh.cleaned"
         if infn.endswith(ext_cleaned):
@@ -50,12 +52,37 @@ class OGAssignDIAMOND(OGAssigner):
         else:
             fn_base = infn
         fn_results = self.run_diamond(infn, fn_base, q_ultra_sens=q_ultra_sens)
-        ogs, scores = self.og_from_diamond_results(fn_results)
-        if ((not q_ultra_sens) or (not self.q_all_seqs_default)) and len(ogs) == 0:
+        assignations = self.og_from_diamond_results(fn_results)
+
+        # Get genes.
+        infile = open(infn, 'r')
+        fasta_data = infile.read()
+        genes = dict(re.findall(r"^>([^\n]+)\n([^>]+)", fasta_data, re.MULTILINE))
+        infile.close()
+
+        reassign = []
+        for gene in genes:
+            if gene not in assignations:
+                assignations[gene] = {
+                    'ogs': [],
+                    'scores': [],
+                }
+            if ((not q_ultra_sens) or (not self.q_all_seqs_default)) and (len(assignations[gene]['ogs']) == 0):
+                reassign.append(gene)
+        if 0 < len(reassign):
+            # Generate a new FASTA with the gene to reassign
+            new_fasta_data = ''
+            for gene in reassign:
+                new_fasta_data = new_fasta_data + '>' + gene + genes[gene] + '\n'
+
+            sensfile_name = infn + '.sens.fa'
+            with open(sensfile_name, 'w') as sensfile:
+                sensfile.write(new_fasta_data)
+
             # Try again with a more sensitive search & all sequences
-            fn_results = self.run_diamond(infn, fn_base, q_ultra_sens=True, q_all_seqs=True)
-            ogs, scores = self.og_from_diamond_results(fn_results)
-        return ogs, scores
+            fn_results = self.run_diamond(sensfile_name, fn_base, q_ultra_sens=True, q_all_seqs=True)
+            assignations = self.og_from_diamond_results(fn_results)
+        return assignations
     
     def run_diamond(self, fn_query, fn_out_base, q_ultra_sens=False, q_all_seqs=False):
         """
@@ -68,11 +95,11 @@ class OGAssignDIAMOND(OGAssigner):
         """
         fn_db = self.d_db + (self.all_seqs_db_name if q_all_seqs else self.profiles_db_name) 
         fn_og_results_out = fn_out_base + ".sh.ogs.txt"
-        with open(os.devnull, 'w') as FNULL:
+        with open(fn_og_results_out + '.log', 'w') as log:
             cmd_list = ["diamond", "blastp", "-d", fn_db, "-q", fn_query, "-o", fn_og_results_out, "--quiet", "-e", "0.001", "--compress", "1", "-p", str(self.nthreads)]
             if q_ultra_sens:
                 cmd_list += ["--ultra-sensitive"]
-            subprocess.call(cmd_list,stdout=FNULL, stderr=FNULL)
+            subprocess.call(cmd_list,stdout=log, stderr=log)
         return fn_og_results_out + ".gz"
 
     @staticmethod
@@ -83,34 +110,46 @@ class OGAssignDIAMOND(OGAssigner):
             fn_og_results_out - fn of compressed DIAMOND results
             q_ignore_sub - ignore any subtrees and just look at overall OGs
         Returns:
-            iog        : List[str] "int.int" or "int" of ordered, ambiguous assignments
+            iog: a dictionay which keys are gene names and values are dicts:
+              ogs: the ordered list of assigned OGs
+              scores: the list of corresponding e-values scores
         Info:
             Hits to other groups are returned if np.log10 difference is less than 10 
             and -np.log10 score > difference.
         """
+        assignations = {}
         ogs = []
         scores = []
         with gzip.open(fn_og_results_out, 'rt') as infile:
             reader = csv.reader(infile, delimiter="\t")
             for l in reader:
+                gene = l[0]
+                if not gene in assignations:
+                    assignations[gene] = {
+                        'ogs': [],
+                        'scores': [],
+                    }
                 og = l[1].split("_")[0]
-                ogs.append(og.split(".",1)[0] if q_ignore_sub else og)
-                scores.append(float(l[-2]))
-        sortedTuples = sorted(zip(scores, ogs))
-        scores = [i for i, j in sortedTuples]
-        ogs = [j for i, j in sortedTuples]
-        unique = [i for i in range(len(ogs)) if ogs[i] not in ogs[:i]]
-        ogs = [ogs[i] for i in unique]
-        scores = [scores[i] for i in unique]
-        if len(ogs) > 0:
-            # filter out all ogs other than those which are potentially worth considering
-            sliver = np.nextafter(0, 1)
-            scores_ml10 = [-np.log10(s+sliver) for s in scores]
-            s0 = scores_ml10[0]
-            # in a test of 15k sequences only 12 passed the first test but failed s>(s0-s)
-            # it is not worth arguing over whether it's a good second criteris 
-            # scores = [s for s in scores if s0-s<10 and s>(s0-s)]
-            scores_ml10 = [s for s in scores_ml10 if s0-s<10]
-            ogs = ogs[:len(scores_ml10)]
-            scores = scores[:len(scores_ml10)]
-        return ogs, scores
+                assignations[gene]['ogs'].append(og.split(".",1)[0] if q_ignore_sub else og)
+                assignations[gene]['scores'].append(float(l[-2]))
+        for gene, values in assignations.items():
+            sortedTuples = sorted(zip(values['scores'], values['ogs']))
+            scores = [i for i, j in sortedTuples]
+            ogs = [j for i, j in sortedTuples]
+            unique = [i for i in range(len(ogs)) if ogs[i] not in ogs[:i]]
+            ogs = [ogs[i] for i in unique]
+            scores = [scores[i] for i in unique]
+            if len(ogs) > 0:
+                # filter out all ogs other than those which are potentially worth considering
+                sliver = np.nextafter(0, 1)
+                scores_ml10 = [-np.log10(s+sliver) for s in scores]
+                s0 = scores_ml10[0]
+                # in a test of 15k sequences only 12 passed the first test but failed s>(s0-s)
+                # it is not worth arguing over whether it's a good second criteris 
+                # scores = [s for s in scores if s0-s<10 and s>(s0-s)]
+                scores_ml10 = [s for s in scores_ml10 if s0-s<10]
+                ogs = ogs[:len(scores_ml10)]
+                scores = scores[:len(scores_ml10)]
+            assignations[gene]['ogs'] = ogs
+            assignations[gene]['scores'] = scores
+        return assignations

--- a/shoot/og_assigner.py
+++ b/shoot/og_assigner.py
@@ -73,18 +73,18 @@ class OGAssignDIAMOND(OGAssigner):
             # Generate a new FASTA with the gene to reassign
             new_fasta_data = ''
             for gene in reassign:
-                new_fasta_data = new_fasta_data + '>' + gene + genes[gene] + '\n'
+                new_fasta_data = new_fasta_data + '>' + gene + '\n' + genes[gene] + '\n'
 
-            sensfile_name = infn + '.sens.fa'
-            with open(sensfile_name, 'w') as sensfile:
+            rematch_file_name = infn + '.rematch.fa'
+            with open(rematch_file_name, 'w') as sensfile:
                 sensfile.write(new_fasta_data)
 
             # Try again with a more sensitive search & all sequences
-            fn_results = self.run_diamond(sensfile_name, fn_base, q_ultra_sens=True, q_all_seqs=True)
-            assignations = self.og_from_diamond_results(fn_results)
+            fn_results = self.run_diamond(rematch_file_name, fn_base, q_ultra_sens=True, q_all_seqs=True, name_extra='.all')
+            assignations.update(self.og_from_diamond_results(fn_results))
         return assignations
     
-    def run_diamond(self, fn_query, fn_out_base, q_ultra_sens=False, q_all_seqs=False):
+    def run_diamond(self, fn_query, fn_out_base, q_ultra_sens=False, q_all_seqs=False, name_extra=''):
         """
         Run DIAMOND against database of orthogroup profiles
         Args:
@@ -94,8 +94,8 @@ class OGAssignDIAMOND(OGAssigner):
             fn_og_results_out - DIAMOND results filename
         """
         fn_db = self.d_db + (self.all_seqs_db_name if q_all_seqs else self.profiles_db_name) 
-        fn_og_results_out = fn_out_base + ".sh.ogs.txt"
-        with open(fn_og_results_out + '.log', 'w') as log:
+        fn_og_results_out = fn_out_base + ".sh.ogs" + (name_extra or '') + ".txt"
+        with open(fn_og_results_out + '.log', 'a') as log:
             cmd_list = ["diamond", "blastp", "-d", fn_db, "-q", fn_query, "-o", fn_og_results_out, "--quiet", "-e", "0.001", "--compress", "1", "-p", str(self.nthreads)]
             if q_ultra_sens:
                 cmd_list += ["--ultra-sensitive"]


### PR DESCRIPTION
This version supports multiple query genes and provides outputs by matching OGs.

There are small changes in the output files:
- added a ".sh.map" file for correspondance between original query names and processed names (when a ".sh.cleaned" file is created)
- ".assign.txt" now has an additional column containing the (coma-separated) list of query genes matching the OG (and the corresponding scores are also all there and coma separated)
- ".fa.sh.msa.fa", ".fa.sh.msa.fa.query.fa", ".sh.msa.fa.ref.fa", ".fa.shoot.tree", ".sh.orthologs.tsv" and ".fa.sh.msa.fa_epa" are now prefixed with their corresponding OG names
- ".sh.orthologs.tsv" has a new "Query" column added as first column to report the corresponding query gene
- ".jplace" files include all the genes matching a given OG

Basically, all the query genes are grouped by matching OGs and then reintegrated in each OG in group (and not one by one).

It may need to be tested a bit more extensively by others with more dataset than mines.
